### PR TITLE
Bugfix: use 'network_topology' instead of removed 'network_topo' in ScenarioSimulator

### DIFF
--- a/epyt_flow/simulation/scenario_simulator.py
+++ b/epyt_flow/simulation/scenario_simulator.py
@@ -144,7 +144,7 @@ class ScenarioSimulator():
 
         if scenario_config is not None:     # Extract .inp file from NetworkTopology if necessary
             if __file_exists(self.__f_inp_in) is False:
-                network_topo = scenario_config.network_topo
+                network_topo = scenario_config.network_topology
                 if network_topo is not None:
                     warnings.info(".inp file not found -- extracting network data from NetworkTopology")
                     network_topo.to_inp_file(self.__f_inp_in)


### PR DESCRIPTION
ScenarioConfig renamed the attribute 'network_topo' to 'network_topology', but ScenarioSimulator.__init__ was still accessing the old name, causing an AttributeError whenever a scenario_config is passed and the .inp file does not exist at the specified path.

Fixes: AttributeError: 'ScenarioConfig' object has no attribute 'network_topo' #30 

